### PR TITLE
Fix bugs that affected parsing of new command to create meetings, handle exceptions due to incorrect user input

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateMeetingCommand.java
@@ -5,11 +5,15 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
+import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * Creates a meeting with a person in the address book

--- a/src/main/java/seedu/address/logic/commands/CreateMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateMeetingCommand.java
@@ -103,8 +103,8 @@ public class CreateMeetingCommand extends Command {
             return new CommandResult(e.toString());
 
         } catch (IndexOutOfBoundsException e) {
-            return new CommandResult("Make sure you have entered " +
-                "the correct amount of information correctly separated!");
+            return new CommandResult("Make sure you have entered "
+                + "the correct amount of information correctly separated!");
 
         } catch (PersonNotFoundException e) {
             return new CommandResult("Oops! The person you are meeting with doesn't exist"

--- a/src/main/java/seedu/address/logic/parser/CreateMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateMeetingCommandParser.java
@@ -21,7 +21,7 @@ public class CreateMeetingCommandParser implements Parser<FindCommand> {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateMeetingCommand.MESSAGE_USAGE));
         }
 
         String meetingInfo = trimmedArgs;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.function.Predicate;
 
@@ -104,7 +105,7 @@ public interface Model {
      * @return a new meeting
      */
     Meeting createNewMeeting(ArrayList<Person> peopleToMeet, String meetingTitle,
-                             String meetingDateAndTime, String meetingLocation);
+                             String meetingDateAndTime, String meetingLocation) throws ParseException;
 
     /**
      * Adds a new meeting to the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -134,7 +135,7 @@ public class ModelManager implements Model {
 
     @Override
     public Meeting createNewMeeting(ArrayList<Person> peopleToMeet, String meetingTitle,
-                                    String meetingDateAndTime, String meetingLocation) {
+                                    String meetingDateAndTime, String meetingLocation) throws ParseException {
         return new Meeting(peopleToMeet, meetingTitle, meetingDateAndTime, meetingLocation);
     }
 

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -20,9 +20,9 @@ public class Meeting {
     private String meetingDateAndTime;
     private String meetingLocation;
 
-    private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy", Locale.US)
+    private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy", Locale.UK)
         .withResolverStyle(ResolverStyle.SMART);
-    private final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm", Locale.US)
+    private final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm", Locale.UK)
         .withResolverStyle(ResolverStyle.SMART);
     private final DateTimeProcessor validator = new DateTimeProcessor(dateFormatter, timeFormatter);
 
@@ -35,10 +35,10 @@ public class Meeting {
      * @param meetingLocation the location of the meeting
      */
     public Meeting(ArrayList<Person> peopleToMeet, String meetingTitle,
-                   String meetingDateAndTime, String meetingLocation) {
+                   String meetingDateAndTime, String meetingLocation) throws ParseException {
         this.peopleToMeet.setPersons(peopleToMeet);
         this.meetingDescription = meetingTitle;
-        this.meetingDateAndTime = meetingDateAndTime;
+        this.meetingDateAndTime = validator.processDateTime(meetingDateAndTime);
         this.meetingLocation = meetingLocation;
     }
 

--- a/src/main/java/seedu/address/model/util/DateTimeProcessor.java
+++ b/src/main/java/seedu/address/model/util/DateTimeProcessor.java
@@ -6,7 +6,10 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.FormatStyle;
+import java.time.format.ResolverStyle;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -69,13 +72,14 @@ public class DateTimeProcessor {
         String dueTime = tempStringArray.length < 2 ? "" : tempStringArray[1];
 
         if (!isDateValid(dueDate)) {
-            throw new ParseException("Meeting date is not in yyyy-MM-dd format", 0);
+            throw new ParseException("Meeting date is not in dd-MM-yyyy format", 0);
         }
 
-        LocalDate inputDue = LocalDate.parse(dueDate);
-        String year = String.valueOf(inputDue.getYear());
-        String month = String.valueOf(inputDue.getMonth());
-        String date = String.valueOf(inputDue.getDayOfMonth());
+        DateTimeFormatter newFormatter = DateTimeFormatter
+            .ofLocalizedDate(FormatStyle.FULL).withLocale(Locale.UK).withResolverStyle(ResolverStyle.SMART);
+
+        LocalDate inputDue = LocalDate.parse(dueDate, this.dateFormatter);
+        String dayAndDate = inputDue.format(newFormatter);
 
         //time pattern of input date in 24 hour format -- HH for 24h, hh for 12h
         DateFormat inputTimeFormat = new SimpleDateFormat("HHmm");
@@ -85,15 +89,15 @@ public class DateTimeProcessor {
         DateFormat outputTimeFormat = new SimpleDateFormat("hh:mm aa"); // aa for AM/ PM
 
         if (Objects.equals(dueTime, "")) {
-            return month + " " + date + " " + year;
+            return dayAndDate;
 
         } else if (!isTimeValid(dueTime)) {
-            throw new ParseException("Meeting date is not in HHmm format", 0);
+            throw new ParseException("Meeting Time is not in HHmm format", 0);
         }
 
         Date inputTime = inputTimeFormat.parse(dueTime);
         String outputTime = outputTimeFormat.format(inputTime);
-        return month + " " + date + " " + year + " " + outputTime;
+        return dayAndDate + " " + outputTime;
     }
 
     // for debugging


### PR DESCRIPTION
## What?
I've noticed some bugs during user testing, when I am unable to create meetings for more than one user, and the meeting date cannot be reformatted to the desired format. Also there are uncaught errors when the user enters the wrong number of arguments when creating a new meeing, or when the person to meet with is not found in the address book. Managed to fix these bugs and make the UI return the appropriate output.

## Why?
These bugs mainly occur due to minor logical lapses in the previous versions of my code. Fixinf these bugs are essential in establishing the set of primary features in v1.2 in full functionality.

## How?
For the convertNameToPerson method in CreateMeetingCommand.java, the filtered list of all persons in the address book is reset after every person to meet is added to the meeting, to avoid the case where subsequent persons to meet are found in the address book. Also the conversion from the default time format to British date format (what the user input for meeting date should be) in the result of processDateTime(dateAndTime) in DateTimeProcessor.java is not executed properly, I have corrected that as well. Lastly I added some catch blocks to handle a few (but not all possible) exceptions due to invalid user input.
