### PR TITLE
Added more examples for meeting sample and enforce date time in creation of new meetings

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -50,33 +50,6 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredMeetings = new FilteredList<>(this.meetingList.getMeetingList());
-
-        // To check
-
-        //        ObservableList<Meeting> internalList = FXCollections.observableArrayList();
-        //        ObservableList<Meeting> internalUnmodifiableList =
-        //                FXCollections.unmodifiableObservableList(internalList);
-        //
-        //        ArrayList<Person> myArray = new ArrayList<>();
-        //
-        //        myArray.add(new Person(new Name("Alex Yeoh"), new Phone("87438807"),
-        //                new Email("alexyeoh@example.com"),
-        //                new Address("Blk 30 Geylang Street 29, #06-40"),
-        //                getTagSet("friends")));
-        //
-        //        myArray.add(new Person(new Name("Bernice Yu"), new Phone("99272758"),
-        //                new Email("berniceyu@example.com"),
-        //                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-        //                getTagSet("colleagues", "friends")));
-        //        try {
-        //            internalList.addAll(this.meetingList.getMeetingList().stream().collect(Collectors.toList()));
-        //            internalList.add(new Meeting(myArray, "Study Session", "06-10-2022 2015", "UTown"));
-        //            internalList.add(new Meeting(myArray, "Ice Skating", "12-10-2022 2015", "Jurong East"));
-        //        } catch (Exception e) {
-        //            System.out.println("Exception: " + e);
-        //        }
-        //
-        //        filteredMeetings = new FilteredList<>(internalList);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/address/model/util/DateTimeProcessor.java
+++ b/src/main/java/seedu/address/model/util/DateTimeProcessor.java
@@ -91,10 +91,11 @@ public class DateTimeProcessor {
         DateFormat outputTimeFormat = new SimpleDateFormat("hh:mm aa"); // aa for AM/ PM
 
         if (Objects.equals(dueTime, "")) {
-            return dayAndDate;
+            throw new ParseException("Meeting time cannot be empty");
 
-        } else if (!isTimeValid(dueTime)) {
-            throw new ParseException("Meeting Time is not in HHmm format");
+        }
+        if (!isTimeValid(dueTime)) {
+            throw new ParseException("Meeting time is not in HHmm format");
         }
 
         Date inputTime = inputTimeFormat.parse(dueTime);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -91,10 +91,10 @@ public class SampleDataUtil {
 
         return new Meeting[] {
             new Meeting(p1, "CS2103", "02-04-2022 1500", "COM3"),
-                new Meeting(p2, "GEA1000", "10-12-2021 0800", "UTOWN"),
-                new Meeting(p3, "Lunch", "02-02-2022 1700", "KR MRT"),
-                new Meeting(p4, "Dinner", "30-11-2022 1700", "Fine Food"),
-                new Meeting(p5, "Supper", "01-10-2022 0000", "Mcdonalds")
+            new Meeting(p2, "GEA1000", "10-12-2021 0800", "UTOWN"),
+            new Meeting(p3, "Lunch", "02-02-2022 1700", "KR MRT"),
+            new Meeting(p4, "Dinner", "30-11-2022 1700", "Fine Food"),
+            new Meeting(p5, "Supper", "01-10-2022 0000", "Mcdonalds")
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -63,11 +63,38 @@ public class SampleDataUtil {
     }
 
     public static Meeting[] getSampleMeetings() throws ParseException, java.text.ParseException {
-        ArrayList<Person> p = new ArrayList<>();
-        p.add(alex);
+        ArrayList<Person> p1 = new ArrayList<>();
+        ArrayList<Person> p2 = new ArrayList<>();
+        ArrayList<Person> p3 = new ArrayList<>();
+        ArrayList<Person> p4 = new ArrayList<>();
+        ArrayList<Person> p5 = new ArrayList<>();
+
+        p1.add(alex);
+
+        p2.add(bernice);
+        p2.add(charlotte);
+
+        p3.add(david);
+        p3.add(irfan);
+        p3.add(roy);
+
+        p4.add(david);
+        p4.add(alex);
+        p4.add(charlotte);
+        p4.add(bernice);
+
+        p5.add(roy);
+        p5.add(alex);
+        p5.add(david);
+        p5.add(bernice);
+        p5.add(charlotte);
 
         return new Meeting[] {
-            new Meeting(p, "CS2103", "02-04-2022 1500", "COM3")
+            new Meeting(p1, "CS2103", "02-04-2022 1500", "COM3"),
+                new Meeting(p2, "GEA1000", "10-12-2021 0800", "UTOWN"),
+                new Meeting(p3, "Lunch", "02-02-2022 1700", "KR MRT"),
+                new Meeting(p4, "Dinner", "30-11-2022 1700", "Fine Food"),
+                new Meeting(p5, "Supper", "01-10-2022 0000", "Mcdonalds")
         };
     }
 


### PR DESCRIPTION
Added more examples for meetings 
Enforced that create meetings must take in both date and time instead of just date. With just the date, it will cause storage to have errors in the creation of meeting objects